### PR TITLE
fix(esp32): 移除每次下载 bin 前多余的 display info 请求

### DIFF
--- a/devices/photo-frame/esp32/src/main.cpp
+++ b/devices/photo-frame/esp32/src/main.cpp
@@ -155,12 +155,6 @@ bool downloadAndDisplay() {
         return false;
     }
 
-    // 获取显示信息（可选，用于日志）
-    DisplayInfo info = apiClient.getDisplayInfo();
-    if (info.valid) {
-        LOG_INFO_F("[Main] 照片 ID: %d, Asset ID: %d\n", info.photoID, info.assetID);
-    }
-
     // 下载 bin 文件
     String receivedChecksum;
     int downloaded = apiClient.downloadBinFile(imageBuffer, actualBufferSize, receivedChecksum);


### PR DESCRIPTION
## Summary

- 移除 `downloadAndDisplay()` 中每次下载 bin 前对 `/api/v1/device/display` 的额外请求
- 该请求仅用于串口日志输出（打印照片 ID / Asset ID），`binURL` 字段从未被实际使用
- `downloadBinFile()` 内部已直接硬编码 `/api/v1/device/display.bin`，两个请求完全独立
- 减少一次不必要的网络往返，提升每次刷新的效率

## Test plan

- [ ] 编译固件确认无报错
- [ ] 烧录后确认设备仍能正常下载并显示图片
- [ ] 抓包确认每次刷新只发一次 `/api/v1/device/display.bin` 请求

🤖 Generated with [Claude Code](https://claude.com/claude-code)