### PR TITLE
feat(display): 批次生成改为异步，解决 NAS 大量照片时超时问题

### DIFF
--- a/backend/internal/api/v1/handler/display_batch_handler.go
+++ b/backend/internal/api/v1/handler/display_batch_handler.go
@@ -130,6 +130,36 @@ func (h *DisplayHandler) resolveDeviceDisplaySelection(c *gin.Context) (*model.D
 	return selection, true
 }
 
+func (h *DisplayHandler) GenerateDailyBatchAsync(c *gin.Context) {
+	var req model.GenerateDailyDisplayBatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, model.Response{Success: false, Error: &model.ErrorInfo{Code: "INVALID_REQUEST", Message: "Invalid request"}})
+		return
+	}
+
+	targetDate := time.Now()
+	if req.Date != "" {
+		parsedDate, err := time.ParseInLocation("2006-01-02", req.Date, time.Local)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, model.Response{Success: false, Error: &model.ErrorInfo{Code: "INVALID_REQUEST", Message: "date format must be YYYY-MM-DD"}})
+			return
+		}
+		targetDate = parsedDate
+	}
+
+	batch, err := h.displayService.StartGenerateDailyBatch(targetDate, req.Force)
+	if err != nil {
+		if err.Error() == "batch generation already running" {
+			c.JSON(http.StatusConflict, model.Response{Success: false, Error: &model.ErrorInfo{Code: "TASK_RUNNING", Message: "批次生成任务正在运行中"}})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, model.Response{Success: false, Error: &model.ErrorInfo{Code: "GENERATE_FAILED", Message: err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.Response{Success: true, Message: "批次生成已启动", Data: h.toDailyBatchResponse(batch)})
+}
+
 func (h *DisplayHandler) GenerateDailyBatch(c *gin.Context) {
 	var req model.GenerateDailyDisplayBatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/backend/internal/api/v1/router/router.go
+++ b/backend/internal/api/v1/router/router.go
@@ -148,6 +148,7 @@ func Setup(db *gorm.DB, cfg *config.Config) (*gin.Engine, *service.Services) {
 			authorized.GET("/display/batch", handlers.Display.GetDailyBatch)
 			authorized.GET("/display/history", handlers.Display.ListDailyBatches)
 			authorized.POST("/display/batch/generate", handlers.Display.GenerateDailyBatch)
+			authorized.POST("/display/batch/generate/async", handlers.Display.GenerateDailyBatchAsync)
 			authorized.GET("/display/render-profiles", handlers.Display.GetRenderProfiles)
 
 			// 照片相关

--- a/backend/internal/service/display_daily_service.go
+++ b/backend/internal/service/display_daily_service.go
@@ -18,8 +18,13 @@ import (
 func (s *displayService) GenerateDailyBatch(date time.Time, force bool) (*model.DailyDisplayBatch, error) {
 	batchDate := normalizeBatchDate(date)
 	existing, err := s.findDailyBatchByDate(batchDate)
-	if err == nil && existing != nil && existing.Status == model.DailyDisplayBatchStatusReady && !force {
-		return existing, nil
+	if err == nil && existing != nil {
+		if existing.Status == model.DailyDisplayBatchStatusRunning && !force {
+			return nil, fmt.Errorf("daily batch for %s is currently being generated", batchDate)
+		}
+		if existing.Status == model.DailyDisplayBatchStatusReady && !force {
+			return existing, nil
+		}
 	}
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
@@ -172,6 +177,70 @@ func (s *displayService) GenerateDailyBatch(date time.Time, force bool) (*model.
 
 	logger.Infof("Generated daily display batch for %s with %d items", batchDate, len(items))
 	return saved, nil
+}
+
+func (s *displayService) StartGenerateDailyBatch(date time.Time, force bool) (*model.DailyDisplayBatch, error) {
+	s.batchGenMu.Lock()
+	if s.batchGenRunning {
+		s.batchGenMu.Unlock()
+		return nil, fmt.Errorf("batch generation already running")
+	}
+	s.batchGenRunning = true
+	s.batchGenMu.Unlock()
+
+	batchDate := normalizeBatchDate(date)
+
+	// upsert a running placeholder so the frontend can poll status
+	var batch model.DailyDisplayBatch
+	err := s.db.Where("date(batch_date) = date(?)", batchDate).First(&batch).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		s.batchGenMu.Lock()
+		s.batchGenRunning = false
+		s.batchGenMu.Unlock()
+		return nil, err
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		batch = model.DailyDisplayBatch{
+			BatchDate: batchDate,
+			Status:    model.DailyDisplayBatchStatusRunning,
+		}
+		if err := s.db.Create(&batch).Error; err != nil {
+			s.batchGenMu.Lock()
+			s.batchGenRunning = false
+			s.batchGenMu.Unlock()
+			return nil, err
+		}
+	} else {
+		if err := s.db.Model(&batch).Updates(map[string]interface{}{
+			"status":        model.DailyDisplayBatchStatusRunning,
+			"error_message": "",
+			"item_count":    0,
+		}).Error; err != nil {
+			s.batchGenMu.Lock()
+			s.batchGenRunning = false
+			s.batchGenMu.Unlock()
+			return nil, err
+		}
+	}
+
+	go func() {
+		defer func() {
+			s.batchGenMu.Lock()
+			s.batchGenRunning = false
+			s.batchGenMu.Unlock()
+		}()
+		if _, err := s.GenerateDailyBatch(date, true); err != nil {
+			logger.Errorf("Async batch generation failed for %s: %v", batchDate, err)
+			s.db.Model(&model.DailyDisplayBatch{}).
+				Where("date(batch_date) = date(?) AND status = ?", batchDate, model.DailyDisplayBatchStatusRunning).
+				Updates(map[string]interface{}{
+					"status":        model.DailyDisplayBatchStatusFailed,
+					"error_message": err.Error(),
+				})
+		}
+	}()
+
+	return &batch, nil
 }
 
 func (s *displayService) GetDailyBatch(date time.Time) (*model.DailyDisplayBatch, error) {
@@ -332,8 +401,13 @@ func (s *displayService) GetRenderProfiles() []model.RenderProfileResponse {
 
 func (s *displayService) ensureDailyBatch(date time.Time) (*model.DailyDisplayBatch, error) {
 	batch, err := s.GetDailyBatch(date)
-	if err == nil && batch != nil && batch.Status == model.DailyDisplayBatchStatusReady {
-		return batch, nil
+	if err == nil && batch != nil {
+		if batch.Status == model.DailyDisplayBatchStatusReady {
+			return batch, nil
+		}
+		if batch.Status == model.DailyDisplayBatchStatusRunning {
+			return nil, fmt.Errorf("daily batch for %s is currently being generated, please retry later", normalizeBatchDate(date))
+		}
 	}
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err

--- a/backend/internal/service/display_service.go
+++ b/backend/internal/service/display_service.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/davidhoo/relive/internal/model"
@@ -33,6 +34,7 @@ type DisplayService interface {
 
 	// 每日展示批次
 	GenerateDailyBatch(date time.Time, force bool) (*model.DailyDisplayBatch, error)
+	StartGenerateDailyBatch(date time.Time, force bool) (*model.DailyDisplayBatch, error)
 	GetDailyBatch(date time.Time) (*model.DailyDisplayBatch, error)
 	ListDailyBatches(limit int) ([]*model.DailyDisplayBatch, error)
 	GetDeviceDisplay(deviceID uint, renderProfile string) (*model.DeviceDisplaySelection, error)
@@ -49,6 +51,9 @@ type displayService struct {
 	deviceRepo        repository.DeviceRepository
 	configService     ConfigService
 	config            *config.Config
+
+	batchGenMu      sync.Mutex
+	batchGenRunning bool
 }
 
 // NewDisplayService 创建展示服务

--- a/frontend/src/api/display.ts
+++ b/frontend/src/api/display.ts
@@ -77,6 +77,14 @@ export const dailyDisplayApi = {
     return response.data.data
   },
 
+  startGenerateBatch: async (payload: GenerateDailyBatchRequest): Promise<DailyDisplayBatch> => {
+    const response = await http.post<ApiResponse<DailyDisplayBatch>>('/display/batch/generate/async', payload)
+    if (!response.data?.data) {
+      throw new Error('批次生成启动失败')
+    }
+    return response.data.data
+  },
+
   getRenderProfiles: async (): Promise<RenderProfileOption[]> => {
     const response = await http.get<ApiResponse<RenderProfileOption[]>>('/display/render-profiles')
     return response.data?.data || []

--- a/frontend/src/views/Display/index.vue
+++ b/frontend/src/views/Display/index.vue
@@ -566,10 +566,22 @@ const loadBatchHistory = async () => {
 const generateDailyBatch = async (force: boolean) => {
   batchGenerating.value = true
   try {
-    await dailyDisplayApi.generateBatch({ force })
-    ElMessage.success(force ? '今日批次已重新生成' : '今日批次生成成功')
-    await loadDailyBatch()
-    await loadBatchHistory()
+    await dailyDisplayApi.startGenerateBatch({ force })
+    // poll until ready or failed (max 4 minutes)
+    for (let i = 0; i < 120; i++) {
+      await new Promise(resolve => setTimeout(resolve, 2000))
+      const batch = await dailyDisplayApi.getTodayBatch()
+      if (batch?.status === 'ready') {
+        ElMessage.success(force ? '今日批次已重新生成' : '今日批次生成成功')
+        await loadDailyBatch()
+        await loadBatchHistory()
+        return
+      }
+      if (batch?.status === 'failed') {
+        throw new Error(batch.error_message || '批次生成失败')
+      }
+    }
+    throw new Error('批次生成超时，请检查服务器日志')
   } catch (error: any) {
     ElMessage.error(error.message || '生成今日批次失败')
   } finally {


### PR DESCRIPTION
## Summary

- 原来「重新生成并覆盖」是同步接口，NAS 上照片多时耗时超过 30 秒导致 axios 超时（`timeout of 30000ms exceeded`）
- 改为异步模式：后端立即返回 `running` 状态批次，goroutine 后台执行生成，前端轮询直至完成

## 变更详情

**后端：**
- `DisplayService` 接口新增 `StartGenerateDailyBatch`
- `displayService` struct 新增 `batchGenMu/batchGenRunning` 防并发重入
- `GenerateDailyBatch` 增加 `running` 状态保护（`force=false` 时直接返回错误）
- `ensureDailyBatch` 遇到 `running` 状态不再触发新的同步生成
- 新增 `GenerateDailyBatchAsync` handler
- 新增路由 `POST /display/batch/generate/async`

**前端：**
- `api/display.ts` 新增 `startGenerateBatch`
- `generateDailyBatch` 改为调用异步接口，每 2 秒轮询 `getTodayBatch`，最长等待 4 分钟

## Test plan

- [ ] 点击「重新生成并覆盖」，按钮进入 loading 状态，页面不再超时
- [ ] 生成完成后批次状态变为 ready，页面自动刷新
- [ ] 生成失败时状态变为 failed，前端显示错误信息
- [ ] 生成进行中再次点击，返回 409 冲突提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)