### PR TITLE
fix: detect concurrent MarkDirty during patrol slice to prevent stale ANN

### DIFF
--- a/backend/internal/service/person_merge_suggestion_service.go
+++ b/backend/internal/service/person_merge_suggestion_service.go
@@ -37,10 +37,11 @@ type PersonMergeSuggestionService interface {
 }
 
 type personMergeSuggestionState struct {
-	Paused         bool      `json:"paused"`
-	Dirty          bool      `json:"dirty"`
-	CursorTargetID uint      `json:"cursor_target_id"`
-	LastRunAt      time.Time `json:"last_run_at,omitempty"`
+	Paused          bool      `json:"paused"`
+	Dirty           bool      `json:"dirty"`
+	CursorTargetID  uint      `json:"cursor_target_id"`
+	LastRunAt       time.Time `json:"last_run_at,omitempty"`
+	DirtyGeneration uint64    `json:"dirty_generation,omitempty"`
 }
 
 type personMergeSuggestionService struct {
@@ -306,6 +307,7 @@ func (s *personMergeSuggestionService) MarkDirty(reason string) error {
 
 	s.state.Dirty = true
 	s.state.CursorTargetID = 0
+	s.state.DirtyGeneration++
 	s.annMu.Lock()
 	s.annDirty = true
 	s.annMu.Unlock()
@@ -360,6 +362,7 @@ func (s *personMergeSuggestionService) RunBackgroundSlice() error {
 
 	// 读取状态后释放锁
 	cursor := s.state.CursorTargetID
+	dirtyGen := s.state.DirtyGeneration
 	s.mu.Unlock()
 
 	// Use background-dedicated repos for the heavy work in this slice.
@@ -424,7 +427,13 @@ func (s *personMergeSuggestionService) RunBackgroundSlice() error {
 	}
 
 	s.task.ProcessedPairs += int64(processedPairs)
-	s.state.CursorTargetID = targets[len(targets)-1].ID
+	// Only advance cursor if MarkDirty was not called during this slice.
+	// A concurrent MarkDirty resets cursor to 0 and bumps DirtyGeneration; if we
+	// detect the bump, keep cursor at 0 so the next run re-scans from scratch with
+	// a fresh ANN index built after the concurrent write.
+	if s.state.DirtyGeneration == dirtyGen {
+		s.state.CursorTargetID = targets[len(targets)-1].ID
+	}
 	s.finishSliceLocked(now, processedPairs, fmt.Sprintf("完成 %d 个目标人物巡检", len(targets)))
 	return nil
 }


### PR DESCRIPTION
## Summary

- 新增 `DirtyGeneration uint64` 字段到 `personMergeSuggestionState`，每次 `MarkDirty` 调用时递增
- `RunBackgroundSlice` 在 slice 开始时捕获 generation，结束时只有 generation 未变才推进 `CursorTargetID`；若 generation 已变（说明 slice 执行期间有并发 MarkDirty），保持 cursor=0，让下一次运行从头重扫并重建 ANN

## Root cause

当 patrol slice 正在运行时，如果用户执行合并操作触发了 `MarkDirty`（将 cursor 重置为 0），slice 完成时会无条件写入 `CursorTargetID = lastTarget.ID`，覆盖掉 MarkDirty 的 cursor=0。下一个 slice 看到 cursor > 所有 target ID，认为本轮巡检完成，设 `dirty=false`——MarkDirty 触发的"从头重扫"信号就此丢失。

**实测症状**：271495（牛牛）于 15:33 CST 完成合并，ANN 在 15:30 开始构建，用到了合并前的旧 prototype；MarkDirty 在 15:33 重置 cursor=0，但被 15:41 完成的 slice 覆盖，导致 264884（84.5% 相似度）始终不出现在合并建议里。

## Test plan

- [ ] 部署后，在 patrol 运行期间触发合并，验证 1 分钟内自动触发重扫（不需等 1 小时）
- [ ] 确认 264884 在下次巡检后出现在 271495 的合并建议中

🤖 Generated with [Claude Code](https://claude.com/claude-code)