### PR TITLE
chore: increase merge suggestion stale re-run interval from 1h to 24h

### DIFF
--- a/backend/internal/service/person_merge_suggestion_service.go
+++ b/backend/internal/service/person_merge_suggestion_service.go
@@ -345,7 +345,7 @@ func (s *personMergeSuggestionService) RunBackgroundSlice() error {
 	if !s.state.Dirty {
 		staleSeconds := s.config.People.MergeSuggestionStaleSeconds
 		if staleSeconds <= 0 {
-			staleSeconds = 3600
+			staleSeconds = 86400
 		}
 		if !s.state.LastRunAt.IsZero() && time.Since(s.state.LastRunAt) > time.Duration(staleSeconds)*time.Second {
 			s.state.Dirty = true

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -96,7 +96,7 @@ const (
 	defaultMergeSuggestionMaxPairsPerRun  = 200
 	defaultMergeSuggestionBatchSize       = 100
 	defaultMergeSuggestionCooldownSeconds = 300
-	defaultMergeSuggestionStaleSeconds   = 3600
+	defaultMergeSuggestionStaleSeconds   = 86400
 	defaultClusteringIntervalMs           = 300
 	defaultANNBuildBatchSize      = 100
 	defaultANNBuildCPUDuty        = 0.5


### PR DESCRIPTION
## Summary

- `defaultMergeSuggestionStaleSeconds` 3600 → 86400（1小时 → 24小时）
- 同步修改 `RunBackgroundSlice` 中 `staleSeconds <= 0` 时的硬编码兜底值

## Why

每小时自动重跑意义很小：所有修改人物数据的操作都有对应 `MarkDirty` 触发，数据不变时重跑结果完全相同。PR #8 的 `DirtyGeneration` 修复已解决并发 MarkDirty 被静默丢失的问题。24小时作为纯兜底手段更合理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)